### PR TITLE
Fix #15, fix #16, fix #17

### DIFF
--- a/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportFixture.cs
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportFixture.cs
@@ -9,6 +9,8 @@
 
     internal class SarifIssueReportFixture
     {
+        public const string RepositoryRootPath = @"c:\Source\Cake.Issues.Reporting.Sarif";
+
         public SarifIssueReportFixture()
         {
             this.Log = new FakeLog { Verbosity = Verbosity.Normal };
@@ -28,7 +30,7 @@
             try
             {
                 var createIssueReportSettings =
-                    new CreateIssueReportSettings(@"c:\Source\Cake.Issues.Reporting.Sarif", reportFile);
+                    new CreateIssueReportSettings(RepositoryRootPath, reportFile);
                 generator.Initialize(createIssueReportSettings);
                 generator.CreateReport(issues);
 

--- a/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
@@ -102,6 +102,8 @@
                 result.RuleIndex.ShouldBe(-1); // because there's no rule metadata to point to.
                 result.Message.Text.ShouldBe("Message Foo.");
                 result.Message.Markdown.ShouldBeNull();
+                result.Level.ShouldBe(FailureLevel.Error);
+                result.Kind.ShouldBe(ResultKind.Fail);
 
                 result.Locations.Count.ShouldBe(1);
                 PhysicalLocation physicalLocation = result.Locations[0].PhysicalLocation;
@@ -129,6 +131,8 @@
                 result.RuleIndex.ShouldBe(0); // The index of the metadata for this rule in the rules array.
                 result.Message.Text.ShouldBe("Message Bar.");
                 result.Message.Markdown.ShouldBe("Message Bar -- now in **Markdown**!");
+                result.Level.ShouldBe(FailureLevel.Warning);
+                result.Kind.ShouldBe(ResultKind.Fail);
 
                 result.Locations.Count.ShouldBe(1);
                 physicalLocation = result.Locations[0].PhysicalLocation;

--- a/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
@@ -1,8 +1,11 @@
 ﻿namespace Cake.Issues.Reporting.Sarif.Tests
 {
+    using System;
     using System.Collections.Generic;
     using Cake.Issues.Testing;
     using Cake.Testing;
+    using Microsoft.CodeAnalysis.Sarif;
+    using Newtonsoft.Json;
     using Shouldly;
     using Xunit;
 
@@ -49,24 +52,78 @@
                     {
                         IssueBuilder
                             .NewIssue("Message Foo.", "ProviderType Foo", "ProviderName Foo")
-                            .InFile(@"src\Cake.Issues.Reporting.Sarif.Tests\SerifIssueReportGeneratorTests.cs", 10)
+                            .InFile(@"src\Cake.Issues.Reporting.Sarif.Tests\SarifIssueReportGeneratorTests.cs", 10)
                             .InProjectFile(@"src\Cake.Issues.Reporting.Sarif.Tests\Cake.Issues.Reporting.Sarif.Tests.csproj")
                             .OfRule("Rule Foo")
                             .WithPriority(IssuePriority.Error)
                             .Create(),
                         IssueBuilder
                             .NewIssue("Message Bar.", "ProviderType Bar", "ProviderName Bar")
-                            .InFile(@"src\Cake.Issues.Reporting.Sarif.Tests\SerifIssueReportGeneratorTests.cs", 12)
-                            .OfRule("Rule Bar")
+                            .InFile(@"src\Cake.Issues.Reporting.Sarif.Tests\SarifIssueReportGeneratorTests.cs", 12)
+                            .OfRule("Rule Bar", new Uri("https://www.example.come/rules/bar.html"))
                             .WithPriority(IssuePriority.Warning)
+                            .WithMessageInMarkdownFormat("Message Bar -- now in **Markdown**!")
                             .Create(),
                     };
 
                 // When
-                var result = fixture.CreateReport(issues);
+                var logContents = fixture.CreateReport(issues);
 
                 // Then
-                // TODO
+                var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logContents);
+
+                // There are two runs because there are two issue providers.
+                sarifLog.Runs.Count.ShouldBe(2);
+
+                Run run = sarifLog.Runs[0];
+                run.Tool.Driver.Name.ShouldBe("ProviderType Foo");
+
+                // This run doesn't have any rules that specify a help URI, so we didn't bother
+                // adding rule metadata.
+                run.Tool.Driver.Rules.ShouldBeNull();
+
+                run.Results.Count.ShouldBe(1);
+
+                Result result = run.Results[0];
+                result.RuleId.ShouldBe("Rule Foo");
+                result.RuleIndex.ShouldBe(-1); // because there's no rule metadata to point to.
+                result.Message.Text.ShouldBe("Message Foo.");
+                result.Message.Markdown.ShouldBeNull();
+
+                result.Locations.Count.ShouldBe(1);
+                PhysicalLocation physicalLocation = result.Locations[0].PhysicalLocation;
+                physicalLocation.ArtifactLocation.Uri.OriginalString.ShouldBe("src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs");
+                physicalLocation.Region.StartLine.ShouldBe(10);
+
+                run.OriginalUriBaseIds.Count.ShouldBe(1);
+                run.OriginalUriBaseIds[SarifIssueReportGenerator.RepoRootUriBaseId].Uri.LocalPath.ShouldBe(SarifIssueReportFixture.RepositoryRootPath);
+
+                run = sarifLog.Runs[1];
+                run.Tool.Driver.Name.ShouldBe("ProviderType Bar");
+
+                // This run has a rule that specifies a help URI, so we added rule metadata.
+                IList<ReportingDescriptor> rules = run.Tool.Driver.Rules;
+                rules.Count.ShouldBe(1);
+
+                ReportingDescriptor rule = rules[0];
+                rule.Id.ShouldBe("Rule Bar");
+                rule.HelpUri.OriginalString.ShouldBe("https://www.example.come/rules/bar.html");
+
+                run.Results.Count.ShouldBe(1);
+
+                result = run.Results[0];
+                result.RuleId.ShouldBe("Rule Bar");
+                result.RuleIndex.ShouldBe(0); // The index of the metadata for this rule in the rules array.
+                result.Message.Text.ShouldBe("Message Bar.");
+                result.Message.Markdown.ShouldBe("Message Bar -- now in **Markdown**!");
+
+                result.Locations.Count.ShouldBe(1);
+                physicalLocation = result.Locations[0].PhysicalLocation;
+                physicalLocation.ArtifactLocation.Uri.OriginalString.ShouldBe("src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs");
+                physicalLocation.Region.StartLine.ShouldBe(12);
+
+                run.OriginalUriBaseIds.Count.ShouldBe(1);
+                run.OriginalUriBaseIds[SarifIssueReportGenerator.RepoRootUriBaseId].Uri.LocalPath.ShouldBe(SarifIssueReportFixture.RepositoryRootPath);
             }
         }
     }

--- a/src/Cake.Issues.Reporting.Sarif/IIssueExtensions.cs
+++ b/src/Cake.Issues.Reporting.Sarif/IIssueExtensions.cs
@@ -90,7 +90,7 @@
                 result.PhysicalLocation.ArtifactLocation =
                     new ArtifactLocation
                     {
-                        UriBaseId = repositoryRoot.FullPath,
+                        UriBaseId = SarifIssueReportGenerator.RepoRootUriBaseId,
                         Uri = new Uri(issue.FilePath(), UriKind.RelativeOrAbsolute),
                     };
             }

--- a/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
@@ -19,6 +19,12 @@
         /// </summary>
         internal const string RepoRootUriBaseId = "REPOROOT";
 
+        /// <summary>
+        /// The name of the result object property bag property that holds the rule URL in the
+        /// unusual case where the ruleId is absent but the URL is present.
+        /// </summary>
+        internal const string RuleUrlPropertyName = "RuleUrl";
+
         private readonly SarifIssueReportFormatSettings sarifIssueReportFormatSettings;
         private List<ReportingDescriptor> rules;
         private Dictionary<string, int> ruleIndices;
@@ -140,7 +146,7 @@
                     // In the unusual case where there is a rule URL but no rule name, we put the
                     // URL in the result's property bag, because there's no rule whose metadata
                     // can hold it.
-                    result.SetProperty("RuleUrl", issue.RuleUrl);
+                    result.SetProperty(RuleUrlPropertyName, issue.RuleUrl);
                 }
             }
 


### PR DESCRIPTION
#15: Suggestion: populate result.message.markdown.
#16: Suggestion: populate rule metadata with helpUri.
#17: Bug: uriBaseId is a symbolic name, not a path.

@michaelcfanning @pascalberger 