### PR TITLE
(GH-88) Migrate from FxCop analyzers to NETAnalyzers

### DIFF
--- a/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
+++ b/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.Reporting.Sarif.ruleset</CodeAnalysisRuleSet>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
@@ -34,10 +35,9 @@
       <Version>0.9.0</Version>
     </PackageReference>
     <PackageReference Include="Cake.Issues.Reporting" Version="0.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-      <Version>3.3.1</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Sarif.Sdk" Version="2.3.5" />
     <PackageReference Include="StyleCop.Analyzers">


### PR DESCRIPTION
FxCopAnalyzers package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers'.

Add **AllEnabledByDefault**
Aggressive or opt-out mode, where all rules are enabled by default as build warnings. You can selectively opt out of individual rules to disable them.

Fixes #88 