### PR TITLE
Run Ubuntu integration tests on 18.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
     - publish: $(Build.SourcesDirectory)/tests/output
       artifact: Integration Tests macOS 10.15 (.NET Core tool)
       displayName: 'Publish generated reports as build artifact'
-  # Integration Tests Ubuntu 16.04 (.NET Core tool)
+  # Integration Tests Ubuntu 18.04 (.NET Core tool)
   - job: Test_ubuntu_DotNetCoreTool
     displayName: Integration Tests Ubuntu 16.04 (.NET Core tool)
     dependsOn: Build


### PR DESCRIPTION
Run Ubuntu integration tests on 18.04 since 16.04 is deprecated