### PR TITLE
(GH-168) Build against Cake 3.0 and update target frameworks

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,12 +4,21 @@
 image: Visual Studio 2022
 
 #---------------------------------#
-#  Build Script                   #
+#  Install .NET                   #
 #---------------------------------#
 install:
-  # Update to latest NuGet version since we require 5.3.0 for embedded icon
-  - ps: nuget update -self
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
+  - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
+  - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 5.0.408 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.405 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 7.0.102 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+  - ps: dotnet --info
 
+#---------------------------------#
+#  Build Script                   #
+#---------------------------------#
 build_script:
   - ps: .\build.ps1 --target=CI
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,18 @@ jobs:
     pool:
       vmImage: 'windows-2022'
     steps:
+    # .NET 5 required for GitVersion
+    - task: UseDotNet@2
+      inputs:
+        version: '5.x'
+      displayName: 'Install .NET 5'
+    - task: UseDotNet@2
+      inputs:
+        version: '6.x'
+      displayName: 'Install .NET 6'
+    - task: UseDotNet@2
+      inputs:
+        version: '7.x'
     - powershell: ./build.ps1
       displayName: 'Build'
     - publish: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
@@ -27,6 +39,10 @@ jobs:
     pool:
       vmImage: 'windows-2019'
     steps:
+    - task: UseDotNet@2
+      inputs:
+        version: '6.x'
+      displayName: 'Install .NET 6'
     - task: NodeTool@0
       inputs:
         versionSpec: '14.x'
@@ -64,6 +80,10 @@ jobs:
     pool:
       vmImage: 'macOS-11'
     steps:
+    - task: UseDotNet@2
+      inputs:
+        version: '6.x'
+      displayName: 'Install .NET 6'
     - task: NodeTool@0
       inputs:
         versionSpec: '14.x'
@@ -92,6 +112,10 @@ jobs:
     pool:
       vmImage: 'ubuntu-18.04'
     steps:
+    - task: UseDotNet@2
+      inputs:
+        version: '6.x'
+      displayName: 'Install .NET 6'
     - task: NodeTool@0
       inputs:
         versionSpec: '14.x'

--- a/nuspec/nuget/Cake.Issues.Reporting.Sarif.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Sarif.nuspec
@@ -26,17 +26,13 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netcoreapp3.1/Cake.Issues.Reporting.Sarif.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1/Cake.Issues.Reporting.Sarif.pdb" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1/Cake.Issues.Reporting.Sarif.xml" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1/Sarif.dll" target="lib\netcoreapp3.1" />
-    <file src="net5.0/Cake.Issues.Reporting.Sarif.dll" target="lib\net5.0" />
-    <file src="net5.0/Cake.Issues.Reporting.Sarif.pdb" target="lib\net5.0" />
-    <file src="net5.0/Cake.Issues.Reporting.Sarif.xml" target="lib\net5.0" />
-    <file src="net5.0/Sarif.dll" target="lib\net5.0" />
     <file src="net6.0/Cake.Issues.Reporting.Sarif.dll" target="lib\net6.0" />
     <file src="net6.0/Cake.Issues.Reporting.Sarif.pdb" target="lib\net6.0" />
     <file src="net6.0/Cake.Issues.Reporting.Sarif.xml" target="lib\net6.0" />
     <file src="net6.0/Sarif.dll" target="lib\net6.0" />
+    <file src="net7.0/Cake.Issues.Reporting.Sarif.dll" target="lib\net7.0" />
+    <file src="net7.0/Cake.Issues.Reporting.Sarif.pdb" target="lib\net7.0" />
+    <file src="net7.0/Cake.Issues.Reporting.Sarif.xml" target="lib\net7.0" />
+    <file src="net7.0/Sarif.dll" target="lib\net5.0" />
   </files>
 </package>

--- a/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.Issues.Reporting.Sarif addin</Description>
     <Authors>Pascal Berger</Authors>

--- a/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
@@ -22,8 +22,8 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Issues" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.Testing" Version="2.0.0" />
+    <PackageReference Include="Cake.Issues" Version="3.0.0-beta0002" />
+    <PackageReference Include="Cake.Issues.Testing" Version="3.0.0-beta0002" />
     <PackageReference Include="Cake.Testing" Version="3.0.0" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
     <PackageReference Include="StyleCop.Analyzers">

--- a/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Cake.Issues" Version="2.0.0" />
     <PackageReference Include="Cake.Issues.Testing" Version="2.0.0" />
-    <PackageReference Include="Cake.Testing" Version="2.0.0" />
+    <PackageReference Include="Cake.Testing" Version="3.0.0" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
+++ b/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Description>Support for creating SARIF compatible files for the Cake.Issues addin for Cake Build Automation System</Description>
     <Authors>Pascal Berger</Authors>
     <Product>Cake.Issues</Product>

--- a/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
+++ b/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
@@ -29,8 +29,8 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="3.0.0" />
-    <PackageReference Include="Cake.Issues" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.Reporting" Version="2.0.0" />
+    <PackageReference Include="Cake.Issues" Version="3.0.0-beta0002" />
+    <PackageReference Include="Cake.Issues.Reporting" Version="3.0.0-beta0002" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
+++ b/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="2.0.0" />
+    <PackageReference Include="Cake.Core" Version="3.0.0" />
     <PackageReference Include="Cake.Issues" Version="2.0.0" />
     <PackageReference Include="Cake.Issues.Reporting" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">

--- a/tests/.config/dotnet-tools.json
+++ b/tests/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/tests/build/build/build.cake
+++ b/tests/build/build/build.cake
@@ -8,7 +8,7 @@ Task("Build")
     DotNetRestore(solutionFile.FullPath);
 
     var settings =
-        new DotNetCoreMSBuildSettings()
+        new DotNetMSBuildSettings()
             .WithTarget("Rebuild")
             .WithLogger(
                 "BinaryLogger," + Context.Tools.Resolve("Cake.Issues.MsBuild*/**/StructuredLogger.dll"),
@@ -18,7 +18,7 @@ Task("Build")
 
     DotNetBuild(
         solutionFile.FullPath,
-        new DotNetCoreBuildSettings
+        new DotNetBuildSettings
         {
             MSBuildSettings = settings
         });


### PR DESCRIPTION
Builds against Cake 3.0 and Cake.Issues 3.0 Beta. Also removes support for .NET Core 3.1 and .NET 5. Add support for .NET 7

Fixes #168 
Fixes #169 
Fixes #170 